### PR TITLE
fix: Support `@ddu-sources/*/main.ts` format sources and execute individually

### DIFF
--- a/denops/@ddu-kinds/source.ts
+++ b/denops/@ddu-kinds/source.ts
@@ -9,13 +9,12 @@ type Params = Record<PropertyKey, never>;
 export class Kind extends BaseKind<Params> {
   override actions: Actions<Params> = {
     async execute(args) {
-      const options = {
-        sources: args.items.map((item) => ({
-          name: (item?.action as ActionData).name,
-          params: args.actionParams,
-        })),
-      };
-      await args.denops.dispatcher.start(options);
+      for (const item of args.items) {
+        const sourceName = (item?.action as ActionData).name;
+        await args.denops.dispatcher.start({
+          name: sourceName,
+        });
+      }
       return ActionFlags.None;
     },
   };

--- a/denops/@ddu-sources/source.ts
+++ b/denops/@ddu-sources/source.ts
@@ -6,6 +6,7 @@ import {
 } from "jsr:@shougo/ddu-vim@^9.0.1/source";
 import type { Item } from "jsr:@shougo/ddu-vim@^9.0.1/types";
 import { basename } from "jsr:@std/path@^1.0.6/basename";
+import { dirname } from "jsr:@std/path@^1.0.6/dirname";
 import type { ActionData } from "../@ddu-kinds/source.ts";
 
 type Params = Record<PropertyKey, never>;
@@ -15,10 +16,20 @@ export class Source extends BaseSource<Params, ActionData> {
   #sourceFiles: string[] = [];
 
   override async onInit(args: OnInitArguments<Params>): Promise<void> {
+    // Get sources with pattern: denops/@ddu-sources/*.ts
     const sourceFiles = await args.denops.eval(
       "globpath(&runtimepath, 'denops/@ddu-sources/*.ts', v:true, v:true)",
     ) as string[];
-    this.#sourceFiles = sourceFiles.map((file) => basename(file, ".ts"));
+
+    // Get sources with pattern: denops/@ddu-sources/*/main.ts
+    const mainSourceFiles = await args.denops.eval(
+      "globpath(&runtimepath, 'denops/@ddu-sources/*/main.ts', v:true, v:true)",
+    ) as string[];
+
+    this.#sourceFiles = [
+      ...sourceFiles.map((file) => basename(file, ".ts")),
+      ...mainSourceFiles.map((file) => basename(dirname(file))),
+    ];
   }
 
   override gather(


### PR DESCRIPTION
The existing code supports the `denops/@ddu-sources/*.ts` directory structure, but does not support the `denops/@ddu-sources/*/main.ts` directory structure.
  Therefore, I modified `@ddu-sources/source.ts` to also support the `denops/@ddu-sources/*/main.ts` directory structure.

Additionally, this plugin passes items to ddu.vim in the form of `{ sources: [{ name: "rg", params: {...} }] }`, but since options.name is not specified, the per-source settings configured with `ddu#custom#patch_local({})` are not applied when executing the execute action.
Therefore, I modified `denops/@ddu-kinds/source.ts` to pass `options.name` to ddu.vim instead of directly specifying the sources array. This allows the sources configuration from `patch_local()` to be used as-is.